### PR TITLE
Fix for issue 79.

### DIFF
--- a/src/edu/umass/ckc/wo/beans/ProbProbGroupEntry.java
+++ b/src/edu/umass/ckc/wo/beans/ProbProbGroupEntry.java
@@ -1,0 +1,36 @@
+package edu.umass.ckc.wo.beans;
+
+public class ProbProbGroupEntry {
+
+	private Integer pgroupId;
+	private Integer probId;
+	private String standardId;
+	private String standardIdABC;
+	
+	public Integer getPgroupId() {
+		return pgroupId;
+	}
+	public void setPgroupId(Integer pgroupId) {
+		this.pgroupId = pgroupId;
+	}
+	public Integer getProbId() {
+		return probId;
+	}
+	public void setProbId(Integer probId) {
+		this.probId = probId;
+	}
+	public String getStandardId() {
+		return standardId;
+	}
+	public void setStandardId(String standardId) {
+		this.standardId = standardId;
+	}
+	public String getStandardIdABC() {
+		return standardIdABC;
+	}
+	public void setStandardIdABC(String standardIdABC) {
+		this.standardIdABC = standardIdABC;
+	}
+	
+	
+}


### PR DESCRIPTION
The new change would work as follows:

Fetch the new entries for the probprobgroup table using the new query.
Delete the entries from the probprobgroup table corresponding to the topicids in the step 1.
Insert the entries of step 1 in the probprobgroup table.