### PR TITLE
updated javax.mail dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
 		<dependency>
 			<groupId>javax.mail</groupId>
 			<artifactId>mail</artifactId>
-			<version>1.5.0-b01</version>
+			<version>1.6.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>


### PR DESCRIPTION
The older library was using TLSv1.1, which is disabled by default starting from java 11. Updating the dependency stops malicious attacks from this entry.